### PR TITLE
Added basic news functionality

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,1 +1,203 @@
 // Enter magic javascript here
+const newsTest = {
+  status: "ok",
+  total_hits: 1731,
+  page: 1,
+  total_pages: 289,
+  page_size: 6,
+  articles: [
+    {
+      title: "Bulls hold off Magic's 4th quarter rally for 126-115 win",
+      author: "Associated Press",
+      published_date: "2022-02-02 04:30:00",
+      published_date_precision: "full",
+      link: "https://www.dailyherald.com/article/20220201/sports/302019846",
+      clean_url: "dailyherald.com",
+      excerpt: "DeMar DeRozan scored a game-high 29 points, and Zach LaVine added 24, and the Chicago Bulls beat the Orlando Magic 126-115",
+      summary: "Chicago Bulls forward DeMar DeRozan, right, shoots against Orlando Magic forward Chuma Okeke, left, during the first half of an NBA basketball game, Tuesday, Feb. 1, 2022, in Chicago. Associated Press Chicago Bulls center Nikola Vucevic, right, battles for the ball with Orlando Magic forward Chuma Okeke, left, during the first half of an NBA basketball game, Tuesday, Feb. 1, 2022, in Chicago. Associated Press Chicago Bulls guard Ayo Dosunmu brings the ball up court against the Orlando Magic during the first half of an NBA basketball game, Tuesday, Feb.",
+      rights: "Copyright 2022 Daily Herald, Paddock Publications, Inc.",
+      rank: 3030,
+      topic: "news",
+      country: "US",
+      language: "en",
+      authors: [
+        "Associated Press",
+        "Mark Gonzalez"
+      ],
+      media: "https://www.dailyherald.com/storyimage/DA/20220201/sports/302019846/AR/0/AR-302019846.jpg&updated=202202012235&imageversion=Facebook&exactH=630&exactW=1200&exactfit=crop&noborder",
+      is_opinion: false,
+      twitter_account: "@dailyherald",
+      _score: 23.631004,
+      _id: "082ec78886c1e85ed54952b3e29aab64"
+    },
+    {
+      title: "Detroit Pistons vs Orlando Magic Tips, Odds and Free Live Stream – NBA 2022",
+      author: null,
+      published_date: "2022-01-28 19:00:20",
+      published_date_precision: "full",
+      link: "https://www.sportsnews.com.au/other/featured/detroit-pistons-vs-orlando-magic-tips-odds-and-free-live-stream-nba-2022/578228",
+      clean_url: "sportsnews.com.au",
+      excerpt: "Two of the association's cellar dwellers will meet at Amway Center when the 11-36 Detroit Pistons face the 9-40 Orlando Magic on Friday night. This is their third meeting this season, with the Pisto",
+      summary: "Amway Center will play host to Saturday's NBA game between Detroit Pistons and Orlando Magic. The game kicks off at 11:10 am with Orlando Magic heading into the game as favourites with the bookmakers. Continue reading for our in-depth preview of the Detroit Pistons vs. Orlando Magic game and give you our free tips and bets. When: Saturday January 29, 2022 at 11:10 am Where: Amway Center Bet 💰: Bet On This Match HERE Watch 📺: Watch Every NBA 🏀 Game Live and For Free HERE! Detroit Pistons vs Orlando Magic Odds \n \n Detroit Pistons vs Orlando Magic Preview Two of the association's cellar dwellers will meet at Amway Center when the 11-36 Detroit Pistons face the 9-40 Orlando Magic on Friday night.",
+      rights: "sportsnews.com.au",
+      rank: 725303,
+      topic: "news",
+      country: "AU",
+      language: "en",
+      authors: [],
+      media: "https://www.sportsnews.com.au/wp-content/uploads/2020/09/NBA-Basketball-Tips-and-Odds.jpg",
+      is_opinion: false,
+      twitter_account: "@sportsnewscomau",
+      _score: 23.28361,
+      _id: "f980a9f3f7fa1d29da5113cbd39e9c88"
+    },
+    {
+      title: "Pistons vs. Magic: Play-by-play, highlights and reactions",
+      author: null,
+      published_date: "2022-01-29 00:05:00",
+      published_date_precision: "full",
+      link: "https://sports.yahoo.com/pistons-vs-magic-play-play-000507388.html",
+      clean_url: "yahoo.com",
+      excerpt: "The Detroit Pistons (11-36) play against the Orlando Magic (40-40) at Amway Center Game Time: 7:00 PM EST on Friday January 28, 2022 Detroit Pistons 0, Orlando Magic 0 (7:00 pm ET) What's the buzz on…",
+      summary: "The Detroit Pistons (11-36) play against the Orlando Magic (40-40) at Amway Center\n\nGame Time: 7:00 PM EST on Friday January 28, 2022\n\nDetroit Pistons 0, Orlando Magic 0 (7:00 pm ET)\n\nWhat's the buzz on Twitter?\n\nCody Taylor @CodyTaylorNBA\n\nCade Cunningham is ready to go pic.twitter.com/I31HynX3p7 – 7:08 PM\n\nEvan Dunlap @BQRMagic\n\nthe Magic have built such a lead in the 'reverse standings' that I don't know tonight's game qualifies as a, ahem, must-lose – 7:02 PM\n\nOrlando Magic PR @Magic_PR\n\nTONIGHT'S STARTERS:\n\nJanuary 28 vs Detroit\n\n#MagicTogether pic.",
+      rights: "yahoo.com",
+      rank: 30,
+      topic: "news",
+      country: "US",
+      language: "en",
+      authors: [],
+      media: "https://s.yimg.com/ny/api/res/1.2/sBZtmdmrpg8LKLmTVkmdWA--/YXBwaWQ9aGlnaGxhbmRlcjt3PTEyMDA7aD04NDQ-/https://s.yimg.com/uu/api/res/1.2/qPrM0Fu2hKo5_tqKL7wYTw--~B/aD05MDA7dz0xMjgwO2FwcGlkPXl0YWNoeW9u/https://media.zenfs.com/en/hoops_hype_usa_today_sports_articles_974/857f4ad2a1e21a395170ce4539fce0a9",
+      is_opinion: false,
+      twitter_account: null,
+      _score: 23.198408,
+      _id: "7697e238cadee13cb7f870c881c1be02"
+    },
+    {
+      title: "Dallas Mavericks vs Orlando Magic Tips, Odds and Free Live Stream – NBA 2022",
+      author: "Joseph",
+      published_date: "2022-01-30 19:15:44",
+      published_date_precision: "full",
+      link: "https://www.sportsnews.com.au/other/featured/dallas-mavericks-vs-orlando-magic-tips-odds-and-free-live-stream-nba-2022/578290",
+      clean_url: "sportsnews.com.au",
+      excerpt: "Playing the second leg of a back-to-back, the Dallas Mavericks will visit the Orlando Magic at Amway Center on Sunday night. This is their second and final meeting this season, with the first going th",
+      summary: "Amway Center will play host to Monday's NBA game between Dallas Mavericks and Orlando Magic. The game kicks off at 11:10 am with Dallas Mavericks heading into the game as favourites with the bookmakers. Continue reading for our in-depth preview of the Dallas Mavericks vs. Orlando Magic game and give you our free tips and bets. When: Monday January 31, 2022 at 11:10 am Where: Amway Center Bet 💰: Bet On This Match HERE Watch 📺: Watch Every NBA 🏀 Game Live and For Free HERE! Dallas Mavericks vs Orlando Magic Odds \n \n Dallas Mavericks vs Orlando Magic Preview Playing the second leg of a back-to-back, the Dallas Mavericks will visit the Orlando Magic at Amway Center on Sunday night.",
+      rights: "sportsnews.com.au",
+      rank: 725303,
+      topic: "news",
+      country: "AU",
+      language: "en",
+      authors: [
+        "Joseph"
+      ],
+      media: "https://www.sportsnews.com.au/wp-content/uploads/2020/09/NBA-Basketball-Tips-and-Odds.jpg",
+      is_opinion: false,
+      twitter_account: "@sportsnewscomau",
+      _score: 23.1845,
+      _id: "0259335222202aee39667e652819c08b"
+    },
+    {
+      title: "Cole Anthony Fined $25K For Profane Remarks Towards Official",
+      author: "Jan",
+      published_date: "2022-01-29 12:55:30",
+      published_date_precision: "full",
+      link: "https://basketball.realgm.com",
+      clean_url: "realgm.com",
+      excerpt: "Cole Anthony Fined $25K For Profane Remarks Towards Official Jan 29, 2022 7:55 AM Orlando Magic guard Cole Anthony was fined $25,000 for directing profane and derogatory remarks towards a game…",
+      summary: "Cole Anthony Fined $25K For Profane Remarks Towards Official\nJan 29, 2022 7:55 AM\n\nOrlando Magic guard Cole Anthony was fined $25,000 for directing profane and derogatory remarks towards a game official. The incident occurred as the Orlando Magic lost to the LA Clippers on Wednesday. On the broadcast, Anthony appeared to be upset over several non-calls as Magic players drove to the basket during the fourth quarter. He was also upset at some foul calls that went against Orlando during the same period of time.",
+      rights: "realgm.com",
+      rank: 22813,
+      topic: "sport",
+      country: "unknown",
+      language: "en",
+      authors: [
+        "Jan"
+      ],
+      media: "https://basketball.realgm.com/images/nba/4.2/wiretap/photos/2006/Anthony_Cole_orl_210329.jpg",
+      is_opinion: false,
+      twitter_account: null,
+      _score: 22.487188,
+      _id: "39127441fbeab95fa1b42b8a1ff98825"
+    },
+    {
+      title: "Wagner outplays Cunningham, lifts Magic past Pistons  Taiwan News",
+      author: "Taiwan News",
+      published_date: "2022-01-29 03:31:01",
+      published_date_precision: "full",
+      link: "https://www.taiwannews.com.tw/en/news/4425817",
+      clean_url: "taiwannews.com.tw",
+      excerpt: "Wagner outplays Cunningham, lifts Magic past Pistons | 2022-01-29 11:31:01",
+      summary: "Orlando Magic guard Jalen Suggs (4) drives to the basket past Detroit Pistons center Isaiah Stewart during the second half of an NBA basketball game F... Orlando Magic guard Jalen Suggs (4) drives to the basket past Detroit Pistons center Isaiah Stewart during the second half of an NBA basketball game Friday, Jan. 28, 2022, in Orlando, Fla. (AP Photo/Scott Audette) Detroit Pistons guard Cory Joseph (18) and center Isaiah Stewart (28) reach for the ball as Orlando Magic center Wendell Carter Jr. (34) drives to the.",
+      rights: "taiwannews.com.tw",
+      rank: 5462,
+      topic: "world",
+      country: "TW",
+      language: "en",
+      authors: [
+        "Taiwan News"
+      ],
+      media: "https://tnimage.s3.hicloud.net.tw/photos/2022/AP/20220129/1068a4af352a4d9aa549a469d898c783.jpg",
+      is_opinion: false,
+      twitter_account: null,
+      _score: 22.4471,
+      _id: "16ee4c0cc030f666806bd4254392abc2"
+    }
+  ],
+  user_input: {
+    q: "\"Orlando Magic\"",
+    search_in: [
+      "title_summary"
+    ],
+    lang: [
+      "en"
+    ],
+    not_lang: null,
+    countries: null,
+    not_countries: null,
+    from: "2022-01-27 00:00:00",
+    to: null,
+    ranked_only: "True",
+    from_rank: null,
+    to_rank: null,
+    sort_by: "relevancy",
+    page: 1,
+    size: 6,
+    sources: null,
+    not_sources: null,
+    topic: null,
+    published_date_precision: null
+  }
+};
+
+const getNews = () => {
+  fetch("https://api.newscatcherapi.com/v2/search?q=%22Orlando%20Magic%22&lang=en&page_size=4", {
+    "method": "GET",
+    "headers": {
+      "x-api-key": "86v6NAjjo3u3X4bpk6vbSB-SUGXO674Z55E-24lONc4"
+    }
+  })
+    .then(response => {
+      return response.json();
+    })
+    .then(data => {
+      console.log(data);
+      displayNews(data);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+};
+
+const displayNews = data => {
+  $(".article-title").each(function (i) {
+    $(this).text(data.articles[i].title);
+  });
+  $(".article-image").each(function (i) {
+    $(this).attr("src", data.articles[i].media);
+  });
+  $(".article-link").each(function (i) {
+    $(this).attr("href", data.articles[i].link);
+  });
+};
+
+// getNews();
+displayNews(newsTest);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                   News
                 </a>
                 <a href="#" class="dropdown-item">
-                Statitics
+                Statistics
                 </a>
               </div>
             </div>
@@ -127,34 +127,33 @@
     <!--new card------------------>
 
 
-    <section id="news-section">
+    <section class="news">
     <div class="container">
       <div class="columns">
         <div class="column is-offset-1">
-          <h2 class="is-size-1">Recent news</h2>
-          <br><br>
+          <h2 class="is-size-1">Recent News</h2>
+          <br>
           <div class="columns">
+
             <div class="column is-9">
               <div class="card">
                 <div class="card-content">
                   <div class="content">
-                    <img id="imgId" src="  "  alt=" ">
-                    <p class="title   has-text-centered ">NEWS</p>
-                      <a href="#" class="is-primary">Read more</a>
+                    <img class="article-image">
+                    <h3 class="article-title has-text-centered"><a>Test</a></h3>
+                    <a class="article-link is-primary" target="_blank" rel="noopener noreferrer">Read more</a>
                   </div>
                 </div>
               </div>
             </div>
 
-
             <div class="column is-9">
               <div class="card">
                 <div class="card-content">
                   <div class="content">
-                    <img id="imgId" src="  "  alt=" ">
-                    <p class="title   has-text-centered ">NEWS</p>
-                    
-                      <a href="#" class="is-primary">Read more</a>
+                    <img class="article-image">
+                    <h3 class="article-title has-text-centered"></h3>
+                    <a class="article-link is-primary" target="_blank" rel="noopener noreferrer">Read more</a>
                   </div>
                 </div>
               </div>
@@ -166,24 +165,21 @@
               <div class="card">
                 <div class="card-content">
                   <div class="content">
-                    <img id="imgId" src="  "  alt=" ">
-                    <p class="title has-text-centered">NEWS</p>
-                    
-                      <a href="#" class="is-primary">Read more</a>
+                    <img class="article-image">
+                    <h3 class="article-title has-text-centered"></h3>
+                    <a class="article-link is-primary" target="_blank" rel="noopener noreferrer">Read more</a>
                   </div>
                 </div>
               </div>
             </div>
 
-
             <div class="column is-9">
               <div class="card">
                 <div class="card-content">
                   <div class="content">
-                    <img id="imgId" src="  "  alt=" ">
-                    <p class="title  has-text-centered ">NEWS</p>
-                    
-                      <a href="#" class="is-primary">Read more</a>
+                    <img class="article-image">
+                    <h3 class="article-title has-text-centered"></h3>
+                    <a class="article-link is-primary" target="_blank" rel="noopener noreferrer">Read more</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
I refactored the news section HTML and added code to script.js to call and display news. I confirmed the code's functionality, but in an effort to avoid reaching the 10,000 call limit for this API, the code is currently commented such that it pulls from a test object, rather than the actual API. I can work more on improving the size and layout and adding functionality to search for a specific player or aspect of the Orlando Magic, but I wanted to push the basic functionality now.